### PR TITLE
Revert "Don't require custom config.py for build, still required to run"

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F10
 ENV LC_ALL=en_US.UTF-8
 WORKDIR /project/tmobile-rbac
 
+COPY server/config.py server/config.py
+
 # Note that the context must be set to the project's root directory
 COPY bin/protogen bin/protogen
 COPY protos/ protos/


### PR DESCRIPTION
Reverts blockchaintp/sawtooth-next-directory#4